### PR TITLE
Added stack trace to CreateRouteError

### DIFF
--- a/packages/hadron-express/src/errors/CreateRouteError.ts
+++ b/packages/hadron-express/src/errors/CreateRouteError.ts
@@ -2,8 +2,8 @@ import HadronErrorHandler from '@brainhubeu/hadron-error-handler';
 
 export default class CreateRouteError extends HadronErrorHandler {
   constructor(routeName: string, error: Error) {
-    super(`Cannot create route ${routeName}`);
-    this.error = error;
-    this.stack = null;
+    super();
+    this.message = `Cannot create route ${routeName}.`;
+    this.stack = error.stack;
   }
 }

--- a/packages/hadron-express/src/errors/CreateRouteError.ts
+++ b/packages/hadron-express/src/errors/CreateRouteError.ts
@@ -2,8 +2,7 @@ import HadronErrorHandler from '@brainhubeu/hadron-error-handler';
 
 export default class CreateRouteError extends HadronErrorHandler {
   constructor(routeName: string, error: Error) {
-    super();
-    this.message = `Cannot create route ${routeName}.`;
+    super(`Cannot create route ${routeName}.`);
     this.stack = error.stack;
   }
 }

--- a/packages/hadron-express/src/hadronToExpress.ts
+++ b/packages/hadron-express/src/hadronToExpress.ts
@@ -41,10 +41,10 @@ const createRoutes = (
           .then(handleResponseSpec(res))
           .catch((error) => {
             const logger = containerProxy.hadronLogger;
+            const createRouteError = new CreateRouteError(routeName, error);
             if (logger) {
-              logger.warn(new CreateRouteError(routeName, error));
+              logger.error(createRouteError);
             }
-
             res.sendStatus(500);
           });
       },


### PR DESCRIPTION
This is a quick fix. I think there should be a refactor in the `hadron-error-handler` package.