### PR TITLE
Adding a script to run unit test on individual packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,14 @@ PORT=8181 npm run test
 
 #### Unit tests
 
+Run unit tests for each package:
 ```sh
 npm run test:unit
+```
+
+Run unit tests for a single package:
+```sh
+npm run test:package <package name>
 ```
 
 #### E2E tests

--- a/package-test.sh
+++ b/package-test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+# this runs unit tests on an individual package
+# Usage example: ./package-test.sh oauth
+./node_modules/mocha/bin/mocha -r ts-node/register packages/hadron-$1/src/__tests__/*

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:fix": "lerna exec --bail=false -- tslint -c \\$LERNA_ROOT_PATH/tslint.json -p \\packages/$LERNA_PACKAGE_NAME/tsconfig.json --format stylish",
     "test": "lerna bootstrap && npm run -s test:unit && npm run -s test:e2e",
     "test:unit": "NODE_ENV=test NODE_PATH=src:lib mocha -r ts-node/register tools/testSetup.ts './**/__tests__/*.ts'",
+    "test:package": "./package-test.sh",
     "test:unit:watch": "npm run test:unit -- --reporter min --watch-extensions ts --watch",
     "test:unit:coverage": "NODE_ENV=test NODE_PATH=src:lib nyc mocha -r ts-node/register tools/testSetup.ts './**/__tests__/*.ts'",
     "test:e2e": "./test.sh",


### PR DESCRIPTION
This basically allows you to run `npm run test:package <package-name>` to run unit tests only for a specific package (i.e. `npm run test:package oauth` will run unit tests only for the oauth package).