### PR TITLE
Fixing #40 (hadron-auth default middleware security)

### DIFF
--- a/packages/hadron-auth/src/HadronAuth.ts
+++ b/packages/hadron-auth/src/HadronAuth.ts
@@ -121,6 +121,10 @@ export const initRoutes = (securedRoutes: ISecuredRoute[]): IRoute[] => {
 };
 
 export const register = (container: any, config: any) => {
+  if (config.authSecret) {
+    container.register('authSecret', config.authSecret);
+  }
+
   routes = initRoutes(config.securedRoutes || []);
   const server = container.take('server');
 

--- a/packages/hadron-auth/src/providers/expressMiddlewareAuthorization.ts
+++ b/packages/hadron-auth/src/providers/expressMiddlewareAuthorization.ts
@@ -15,17 +15,26 @@ const expressMiddlewareAuthorization = (container: any) => {
       const userRepository = container.take('userRepository');
       const roleRepository = container.take('roleRepository');
 
-      const token = req.headers.authorization;
+      console.log(req.headers);
 
-      const decoded: any = jwt.decode(token);
+      const token = req.headers.authorization.split(' ')[1];
+      const secret = container.take('authSecret');
+
+      console.log(token);
+
+      const id: any = jwt.verify(token, secret);
+
+      console.log(id);
 
       const user = await userRepository.findOne({
-        where: { id: decoded.id },
+        where: { id },
         relations: ['roles'],
       });
 
+      console.log(user);
+
       if (!user) {
-        return res.status(403).json({ error: errorResponse });
+        return res.status(401).json({ error: errorResponse });
       }
 
       const allRoles = await roleRepository.find();
@@ -37,9 +46,10 @@ const expressMiddlewareAuthorization = (container: any) => {
         return next();
       }
 
-      return res.status(403).json({ error: errorResponse });
+      return res.status(401).json({ error: errorResponse });
     } catch (error) {
-      return res.status(403).json({ error: errorResponse });
+      console.log(error);
+      return res.status(401).json({ error: errorResponse });
     }
   };
 };

--- a/packages/hadron-auth/src/providers/expressMiddlewareAuthorization.ts
+++ b/packages/hadron-auth/src/providers/expressMiddlewareAuthorization.ts
@@ -15,23 +15,15 @@ const expressMiddlewareAuthorization = (container: any) => {
       const userRepository = container.take('userRepository');
       const roleRepository = container.take('roleRepository');
 
-      console.log(req.headers);
-
       const token = req.headers.authorization.split(' ')[1];
       const secret = container.take('authSecret');
 
-      console.log(token);
-
       const id: any = jwt.verify(token, secret);
-
-      console.log(id);
 
       const user = await userRepository.findOne({
         where: { id },
         relations: ['roles'],
       });
-
-      console.log(user);
 
       if (!user) {
         return res.status(401).json({ error: errorResponse });
@@ -48,7 +40,6 @@ const expressMiddlewareAuthorization = (container: any) => {
 
       return res.status(401).json({ error: errorResponse });
     } catch (error) {
-      console.log(error);
       return res.status(401).json({ error: errorResponse });
     }
   };


### PR DESCRIPTION
See #40 for information. Will add docs along with the entire `hadron-auth` docs refactor.